### PR TITLE
Fix stop/start race condition in speech app

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -99,13 +99,11 @@ export default function SpeechToTextApp() {
 
   // Mock speech recognition function
   const startMockRecording = useCallback(() => {
-    debugger
     if (mockIntervalRef.current) {
       clearInterval(mockIntervalRef.current)
     }
 
     mockIntervalRef.current = setInterval(() => {
-        debugger
       if (!isRecordingRef.current) return
 
       const transcript = MOCK_TRANSCRIPTS[mockTranscriptIndexRef.current % MOCK_TRANSCRIPTS.length]
@@ -338,10 +336,12 @@ export default function SpeechToTextApp() {
       // Mock mode recording
       if (isRecording) {
         setIsRecording(false)
+        isRecordingRef.current = false
         stopMockRecording()
         toast.info('Mock recording stopped')
       } else {
         setIsRecording(true)
+        isRecordingRef.current = true
         startMockRecording()
         toast.success('Mock recording started - simulating speech!')
       }
@@ -355,6 +355,7 @@ export default function SpeechToTextApp() {
       if (isRecording) {
         // Set state first to prevent race condition in onend callback
         setIsRecording(false)
+        isRecordingRef.current = false
         setIsProcessing(false)
         recognitionRef.current?.stop()
         if (intervalRef.current) {
@@ -363,6 +364,7 @@ export default function SpeechToTextApp() {
         toast.info('Recording stopped')
       } else {
         setIsRecording(true)
+        isRecordingRef.current = true
         recognitionRef.current?.start()
         toast.success('Recording started - speak now!')
       }
@@ -378,6 +380,7 @@ export default function SpeechToTextApp() {
         recognitionRef.current?.stop()
       }
       setIsRecording(false)
+      isRecordingRef.current = false
       setIsProcessing(false)
     }
     


### PR DESCRIPTION
## Summary
- fix recording logic so `isRecordingRef` updates immediately when toggling
- remove stray `debugger` statements from mock recording

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68882c4680ec83249fbd226a5769dea3