### PR TITLE
Streamline UI with single transcript text box

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -14,13 +14,10 @@
   "mockModeActive": "🎭 Mock Mode Active - Simulating speech recognition for testing",
   "processing": "Processing",
   "confidence": "Confidence",
-  "leftPanel": "Left Panel",
-  "rightPanel": "Right Panel (Speech-to-Text)",
+  "transcript": "Transcript",
   "clear": "Clear",
-  "summarize": "Summarize",
   "placeholder": {
-    "left": "Text will appear here...",
-    "right": "Speech will be transcribed here..."
+    "transcript": "Speech will be transcribed here..."
   },
   "recording": {
     "start": "Start Recording",
@@ -40,23 +37,12 @@
     "leftCopied": "Left content copied to clipboard",
     "clipboardUnsupported": "Clipboard not supported in this browser",
     "leftCleared": "Left panel cleared",
-    "rightCleared": "Right panel cleared",
+    "transcriptCleared": "Transcript cleared",
     "speechRecognitionError": "Speech recognition error: {{error}}",
     "microphoneError": "Failed to access microphone",
     "openaiError": "OpenAI transcription error",
     "exported": "Exported as {{filename}}.{{ext}}",
-    "exportDocxError": "Failed to export as DOCX",
-    "textSummarized": "Text summarized",
-    "summarizeError": "Failed to summarize text"
-  },
-  "commandPalette": {
-    "title": "Command Palette",
-    "overwrite": "Overwrite left with right content",
-    "append": "Append right content to left content",
-    "copy": "Copy left content to clipboard",
-    "clearLeft": "Clear left panel",
-    "clearRight": "Clear right panel",
-    "switchPanels": "Switch between panels"
+    "exportDocxError": "Failed to export as DOCX"
   },
   "unsupported": "Speech recognition is not supported in this browser. Please use Chrome, Edge, or Safari, or enable Mock Mode for testing.",
   "openai": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -14,13 +14,10 @@
   "mockModeActive": "🎭 Modo Simulado Activo - Simulando reconocimiento de voz para pruebas",
   "processing": "Procesando",
   "confidence": "Confianza",
-  "leftPanel": "Panel Izquierdo",
-  "rightPanel": "Panel Derecho (Voz a Texto)",
+  "transcript": "Transcripción",
   "clear": "Limpiar",
-  "summarize": "Resumir",
   "placeholder": {
-    "left": "El texto aparecerá aquí...",
-    "right": "La voz se transcribirá aquí..."
+    "transcript": "La voz se transcribirá aquí..."
   },
   "recording": {
     "start": "Iniciar grabación",
@@ -40,23 +37,12 @@
     "leftCopied": "Contenido izquierdo copiado al portapapeles",
     "clipboardUnsupported": "El portapapeles no está soportado en este navegador",
     "leftCleared": "Panel izquierdo limpiado",
-    "rightCleared": "Panel derecho limpiado",
+    "transcriptCleared": "Transcripción limpiada",
     "speechRecognitionError": "Error de reconocimiento de voz: {{error}}",
     "microphoneError": "No se pudo acceder al micrófono",
     "openaiError": "Error de transcripción de OpenAI",
     "exported": "Exportado como {{filename}}.{{ext}}",
-    "exportDocxError": "No se pudo exportar como DOCX",
-    "textSummarized": "Texto resumido",
-    "summarizeError": "No se pudo resumir el texto"
-  },
-  "commandPalette": {
-    "title": "Atajos",
-    "overwrite": "Reemplazar izquierda con derecha",
-    "append": "Añadir contenido derecho al izquierdo",
-    "copy": "Copiar contenido izquierdo al portapapeles",
-    "clearLeft": "Limpiar panel izquierdo",
-    "clearRight": "Limpiar panel derecho",
-    "switchPanels": "Cambiar entre paneles"
+    "exportDocxError": "No se pudo exportar como DOCX"
   },
   "unsupported": "El reconocimiento de voz no está soportado en este navegador. Usa Chrome, Edge o Safari, o habilita el Modo Simulado para pruebas.",
   "openai": {


### PR DESCRIPTION
## Summary
- Replace dual-pane interface with a single transcription textarea and recording controls
- Update i18n resources to support new transcript panel and messages

## Testing
- `npx biome format src/app/page.tsx src/locales/en.json src/locales/es.json --write`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ab13ca0188324ac024fbf4d6ad2b3