### PR TITLE
feat: add top mic button with voice waves

### DIFF
--- a/src/components/voice-waves.tsx
+++ b/src/components/voice-waves.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from "react";
+
+export function VoiceWaves() {
+  return (
+    <>
+      <div className="pointer-events-none absolute -inset-4 flex items-center justify-center">
+        <div className="flex items-center justify-center gap-1">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <span
+              key={i}
+              className="w-1 bg-white rounded-full"
+              style={{
+                height: "8px",
+                animation: "wave 1s ease-in-out infinite",
+                animationDelay: `${i * 0.1}s`,
+                transformOrigin: "bottom",
+              }}
+            />
+          ))}
+        </div>
+      </div>
+      <style jsx>{`
+        @keyframes wave {
+          0%, 100% {
+            transform: scaleY(0.3);
+          }
+          50% {
+            transform: scaleY(1);
+          }
+        }
+      `}</style>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- move recording button to top as rounded mic icon
- show animated voice waves while recording
- log recorded audio as base64 when capture stops

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f94dc2a808324a0554bedd589eb25